### PR TITLE
fix: use -short flag in GoReleaser test hook

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -3,7 +3,7 @@ version: 2
 before:
   hooks:
     - go mod tidy
-    - go test ./...
+    - go test -short ./...
 
 builds:
   - binary: secure-backup


### PR DESCRIPTION
## Problem

The v1.0.0 release workflow failed because GoReleaser's `before.hooks` runs `go test ./...`, which includes `internal/encrypt` integration tests. These tests require GPG keys generated by a helper script that isn't available on the release runner (`exit status 127`).

## Fix

Change the hook to `go test -short ./...`. The encrypt tests already check `testing.Short()` and skip when keys are unavailable. Full test coverage is handled by the separate Tests CI workflow.

## After merge

Delete the v1.0.0 tag and re-tag to trigger a clean release:
```bash
git tag -d v1.0.0
git push origin :refs/tags/v1.0.0
git tag -a v1.0.0 -m 'v1.0.0'
git push origin v1.0.0
```