### PR TITLE
perf: improve backup pipeline performance for large directories

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/icemarkom/secure-backup
 go 1.26.0
 
 require (
+	github.com/klauspost/pgzip v1.2.6
 	github.com/schollz/progressbar/v3 v3.19.0
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1
@@ -13,6 +14,7 @@ require (
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/klauspost/compress v1.18.4 // indirect
 	github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,10 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/klauspost/compress v1.18.4 h1:RPhnKRAQ4Fh8zU2FY/6ZFDwTVTxgJ/EMydqSTzE9a2c=
+github.com/klauspost/compress v1.18.4/go.mod h1:R0h/fSBs8DE4ENlcrlib3PsXS61voFxhIs2DeRhCvJ4=
+github.com/klauspost/pgzip v1.2.6 h1:8RXeL5crjEUFnR2/Sn6GJNWtSQ3Dk8pq4CL3jvdDyjU=
+github.com/klauspost/pgzip v1.2.6/go.mod h1:Ch1tH69qFZu15pkjo5kYi6mth2Zzwzt50oCQKQE9RUs=
 github.com/mattn/go-runewidth v0.0.16 h1:E5ScNMtiwvlvB5paMFdw9p4kSQzbXFikJ5SQO6TULQc=
 github.com/mattn/go-runewidth v0.0.16/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db h1:62I3jR2EmQ4l5rM/4FEfDWcRD+abF5XlKShorW5LRoQ=

--- a/internal/compress/gzip.go
+++ b/internal/compress/gzip.go
@@ -1,9 +1,10 @@
 package compress
 
 import (
-	"compress/gzip"
 	"fmt"
 	"io"
+
+	gzip "github.com/klauspost/pgzip"
 )
 
 // GzipCompressor implements the Compressor interface using gzip

--- a/internal/encrypt/gpg_test.go
+++ b/internal/encrypt/gpg_test.go
@@ -334,7 +334,7 @@ func TestGPGEncryptor_WrongKey(t *testing.T) {
 	assert.Error(t, err)
 }
 
-func TestGPGEncryptor_DecryptNonArmored(t *testing.T) {
+func TestGPGEncryptor_DecryptInvalidData(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping GPG integration test in short mode")
 	}
@@ -347,8 +347,8 @@ func TestGPGEncryptor_DecryptNonArmored(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	// Pass raw binary data (not armored) — should return explicit error
-	_, err = decryptor.Decrypt(bytes.NewReader([]byte("this is not armored GPG data")))
+	// Pass invalid binary data — should return error from ReadMessage
+	_, err = decryptor.Decrypt(bytes.NewReader([]byte("this is not valid GPG data")))
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to decode armored input")
+	assert.Contains(t, err.Error(), "failed to read encrypted message")
 }


### PR DESCRIPTION
Fixes #24

## Changes

### 1. Remove ASCII armor from GPG encryption
- Removed `armor.Encode()` wrapper — binary GPG output (~33% smaller)
- Removed `armor.Decode()` from decrypt — reads binary directly
- Removed `armor` import entirely from `gpg.go`

### 2. Switch to parallel gzip (pgzip)
- Replaced `compress/gzip` with `github.com/klauspost/pgzip`
- Uses all CPU cores automatically for parallel block compression
- Drop-in replacement, identical API

### 3. Add buffered I/O to pipeline
- 1 MB buffer on tar→compress pipe (`pipeBufferSize` const)
- Reduces goroutine contention from zero-buffered `io.Pipe()`

## Breaking Change
Backup files now use **binary GPG format** instead of ASCII-armored. Existing armored backups are not compatible with this version.

## Test Results
All tests pass with no regressions.