### PR TITLE
fix: verify partial output before error, full SHA256, disable completion

### DIFF
--- a/agent_prompt.md
+++ b/agent_prompt.md
@@ -501,6 +501,13 @@
 - Fix: Guard `lock.Acquire()` with `!backupDryRun` in `cmd/backup.go`
 - E2E regression tests added for dry-run in all subcommands
 
+**Bug Fix**: Verify Partial Output Before Error ✅ FIXED — [#10](https://github.com/icemarkom/secure-backup/issues/10)
+- `verify --file=...` (without `--private-key`) displayed manifest/checksum success before the error
+- Fix: Validate all required flags before any output in `cmd/verify.go`
+- Full SHA256 checksums now displayed (no truncation) in verify and list output
+- Cobra `completion` subcommand disabled
+- E2E regression test updated (step 9c asserts no partial output)
+
 ---
 
 ## Architecture
@@ -838,6 +845,9 @@ Example: `backup_documents_20260207_165324.tar.gz.gpg`
 | 2026-02-15 | Branch+PR workflow | Switched from direct-to-main pushes to mandatory branch+PR workflow. All changes must go through feature branches and Pull Requests. Auto-close keywords (`Fixes #N`) now work via merged PRs. |
 | 2026-02-15 | Performance issue filed (#24) | Identified 3 bottlenecks in backup pipeline: ASCII armor (+33% output bloat), single-threaded stdlib gzip, zero-buffered io.Pipe(). Combined fix expected 3-5× speedup for multi-GB backups. |
 | 2026-02-15 | Performance fixes implemented (#24) | Removed ASCII armor (binary GPG only, breaking change), switched to pgzip (parallel gzip), added 1 MB buffered I/O on tar→compress pipe. All tests pass. |
+| 2026-02-15 | Verify partial output fix (#10) | Moved `--private-key` validation before manifest output in `verify.go`. No partial success output before errors. |
+| 2026-02-15 | Full SHA256 display | Removed `[:16]` truncation from verify and list checksum output. Full hash is useful for scripting and manual comparison. |
+| 2026-02-15 | Cobra completion disabled | `CompletionOptions.DisableDefaultCmd = true` on root command. Can be re-enabled later if needed. |
 
 ---
 
@@ -908,7 +918,7 @@ golangci-lint run
 ---
 
 **Last Updated**: 2026-02-15  
-**Last Updated By**: Agent (conversation 2bfb4839-a8e1-44df-9e3c-46af1db48e81)  
+**Last Updated By**: Agent (conversation 7e12a5cc-7ff6-47af-a90b-0f7c921bf31e)  
 **Project Phase**: v1.0.0 Release ✅  
 **Production Trust Score**: 7.5/10 — All productionization items resolved  
 **Productionization**: P1-P7, P10-P13, P16-P19 ✅ | P8-P9, P14-P15 ⛔ | **ALL ITEMS RESOLVED** 🎉  

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -61,7 +61,7 @@ func runList(cmd *cobra.Command, args []string) error {
 			fmt.Printf("  Source:   %s\n", m.SourcePath)
 			fmt.Printf("  Tool:     %s %s\n", m.CreatedBy.Tool, m.CreatedBy.Version)
 			fmt.Printf("  Host:     %s\n", m.CreatedBy.Hostname)
-			fmt.Printf("  Checksum: %s...\n", m.ChecksumValue[:16])
+			fmt.Printf("  Checksum: %s\n", m.ChecksumValue)
 		} else {
 			fmt.Printf("  (No manifest available)\n")
 		}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -18,6 +18,9 @@ var rootCmd = &cobra.Command{
 	Short:         "Secure, encrypted backups for any directory",
 	Long:          `Create GPG-encrypted, compressed backups of any directory with automated retention management.`,
 	SilenceErrors: true,
+	CompletionOptions: cobra.CompletionOptions{
+		DisableDefaultCmd: true,
+	},
 }
 
 var versionCmd = &cobra.Command{

--- a/test-scripts/e2e_test.sh
+++ b/test-scripts/e2e_test.sh
@@ -249,7 +249,11 @@ MANUAL_OUTPUT=$("$BINARY" verify --file "$BACKUP_FILE" 2>&1 || true)
 echo "$MANUAL_OUTPUT" | grep -q "private-key" || fail "Missing --private-key error not shown"
 echo "$MANUAL_OUTPUT" | grep -q "Usage:" || fail "Missing conditional flag should show Usage:"
 
-pass "Missing conditional flag (manual): usage shown"
+# No partial success output should appear before the error
+echo "$MANUAL_OUTPUT" | grep -q "Manifest:" && fail "Partial output shown before error"
+echo "$MANUAL_OUTPUT" | grep -q "Checksum:" && fail "Partial output shown before error"
+
+pass "Missing conditional flag (manual): usage shown, no partial output"
 
 # 9d: --help should work
 step "Testing --help output"


### PR DESCRIPTION
Fixes #10

## Changes

- **Verify validation reorder**: Check `--private-key` requirement before any manifest/checksum output to prevent confusing mixed success+error output
- **Full SHA256 display**: Removed `[:16]` truncation from checksum output in verify and list commands
- **Cobra completion disabled**: `CompletionOptions.DisableDefaultCmd = true` on root command
- **E2E regression test**: Step 9c asserts no partial output (Manifest/Checksum lines) before errors
- **Documentation**: Updated agent_prompt.md with bug fix entry and decision log