### PR TITLE
fix: retention uses count instead of days

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A high-performance backup tool written in Go that creates encrypted, compressed 
 - **Gzip Compression**: 60-80% size reduction for most data
 - **Streaming Pipeline**: Efficient memory usage regardless of backup size
 - **Backup Manifests**: Automatic checksum verification and metadata tracking
-- **Retention Management**: Automatic cleanup of old backups
+- **Retention Management**: Keep only the last N backups
 - **Verify Integrity**: Quick and full verification modes
 - **List Backups**: View all backups with age and size information
 - **Production Hardened**: Atomic writes, backup locking, signal handling, secure defaults
@@ -381,7 +381,7 @@ RESTORE: File → DECRYPT → DECOMPRESS → EXTRACT → Destination
 Add to your crontab (`crontab -e`):
 
 ```bash
-# Daily backup at 2 AM with 30-day retention
+# Daily backup at 2 AM, keep last 30 backups
 0 2 * * * /usr/local/bin/secure-backup backup --source /data --dest /backups --public-key ~/.gnupg/backup-pub.asc --retention 30
 ```
 

--- a/agent_prompt.md
+++ b/agent_prompt.md
@@ -33,7 +33,7 @@
 - GPG encryption (RSA 4096-bit, binary format)
 - Parallel gzip compression via pgzip (level 6, ~60-80% reduction)
 - Streaming architecture (constant 10-50MB memory, 1 MB buffered pipes)
-- Retention management (auto-cleanup old backups)
+- Retention management (keep last N backups)
 - Path traversal protection
 
 ### ✅ Phase 2: Build & Release (COMPLETE)
@@ -848,6 +848,7 @@ Example: `backup_documents_20260207_165324.tar.gz.gpg`
 | 2026-02-15 | Verify partial output fix (#10) | Moved `--private-key` validation before manifest output in `verify.go`. No partial success output before errors. |
 | 2026-02-15 | Full SHA256 display | Removed `[:16]` truncation from verify and list checksum output. Full hash is useful for scripting and manual comparison. |
 | 2026-02-15 | Cobra completion disabled | `CompletionOptions.DisableDefaultCmd = true` on root command. Can be re-enabled later if needed. |
+| 2026-02-15 | Retention changed from days to count ([#27](https://github.com/icemarkom/secure-backup/issues/27)) | `--retention N` now means "keep last N backups" instead of "delete backups older than N days." Count-based retention works correctly regardless of backup frequency (hourly, daily, weekly). `DefaultKeepLast = 0` constant in `internal/retention`. |
 
 ---
 


### PR DESCRIPTION
Fixes #27

## Problem
`--retention N` meant "delete backups older than N days," which presumes daily backups. With hourly backups, `--retention 30` keeps 720+ files instead of 30.

## Fix
Changed `--retention N` to "keep the last N backups, delete the rest" (sorted by mtime, newest first).

### Changes
- **`internal/retention/policy.go`** — `DefaultKeepLast=0` constant, `KeepLast` field, sort-by-mtime count-based deletion
- **`internal/retention/policy_test.go`** — 12 tests (7 updated + 3 new)
- **`cmd/backup.go`** — flag help text, policy construction, log message
- **`README.md`** / **`USAGE.md`** / **`agent_prompt.md`** — all retention references updated

### Tests
```
go test ./... — all packages PASS
go test ./internal/retention/ -v — 12/12 PASS
```