### PR TITLE
fix: enforce silent-by-default for all commands

### DIFF
--- a/agent_prompt.md
+++ b/agent_prompt.md
@@ -508,6 +508,11 @@
 - Cobra `completion` subcommand disabled
 - E2E regression test updated (step 9c asserts no partial output)
 
+**Bug Fix**: Silent-by-Default Violations ✅ FIXED — [#29](https://github.com/icemarkom/secure-backup/issues/29)
+- `backup` retention message printed with inverted `!backupVerbose` condition (output only when NOT verbose)
+- `verify` manifest/checksum display always printed regardless of `--verbose`
+- Fix: Removed inverted condition in `cmd/backup.go`, gated manifest display in `cmd/verify.go`
+
 ---
 
 ## Architecture
@@ -849,6 +854,7 @@ Example: `backup_documents_20260207_165324.tar.gz.gpg`
 | 2026-02-15 | Full SHA256 display | Removed `[:16]` truncation from verify and list checksum output. Full hash is useful for scripting and manual comparison. |
 | 2026-02-15 | Cobra completion disabled | `CompletionOptions.DisableDefaultCmd = true` on root command. Can be re-enabled later if needed. |
 | 2026-02-15 | Retention changed from days to count ([#27](https://github.com/icemarkom/secure-backup/issues/27)) | `--retention N` now means "keep last N backups" instead of "delete backups older than N days." Count-based retention works correctly regardless of backup frequency (hourly, daily, weekly). `DefaultKeepLast = 0` constant in `internal/retention`. |
+| 2026-02-15 | Silent-by-default fix ([#29](https://github.com/icemarkom/secure-backup/issues/29)) | Fixed 2 violations: (1) `cmd/backup.go` retention message used inverted `!backupVerbose` condition, (2) `cmd/verify.go` manifest/checksum display was ungated. All output now requires `--verbose` except `list`, `version`, dry-run, and stderr warnings. |
 
 ---
 

--- a/cmd/backup.go
+++ b/cmd/backup.go
@@ -139,12 +139,10 @@ func runBackup(cmd *cobra.Command, args []string) error {
 			DryRun:    backupDryRun,
 		}
 
-		deletedCount, err := retention.ApplyPolicy(retentionPolicy)
+		_, err := retention.ApplyPolicy(retentionPolicy)
 		if err != nil {
 			// Don't fail the backup if retention cleanup fails
 			fmt.Fprintf(os.Stderr, "Warning: retention cleanup failed: %v\n", err)
-		} else if deletedCount > 0 && !backupVerbose {
-			fmt.Printf("Deleted %d old backup(s) (keeping last %d)\n", deletedCount, backupRetention)
 		}
 	}
 

--- a/cmd/verify.go
+++ b/cmd/verify.go
@@ -157,10 +157,10 @@ func validateAndDisplayManifest(backupFile string, verbose bool) (*manifest.Mani
 		)
 	}
 
-	// Display manifest info
-	fmt.Printf("Manifest: ✓ Found\n")
-	fmt.Printf("Checksum: ✓ Valid (%s: %s)\n", m.ChecksumAlgorithm, m.ChecksumValue)
+	// Display manifest info (only in verbose mode — silent by default)
 	if verbose {
+		fmt.Printf("Manifest: ✓ Found\n")
+		fmt.Printf("Checksum: ✓ Valid (%s: %s)\n", m.ChecksumAlgorithm, m.ChecksumValue)
 		fmt.Printf("Created:  %s by %s %s on %s\n",
 			m.CreatedAt.Format("2006-01-02 15:04:05"),
 			m.CreatedBy.Tool, m.CreatedBy.Version, m.CreatedBy.Hostname)


### PR DESCRIPTION
Fixes #29

Two violations of silent-by-default principle:

1. **cmd/backup.go** — Retention deletion message used inverted `!backupVerbose` condition, printing only when verbose was OFF
2. **cmd/verify.go** — Manifest/checksum display always printed regardless of `--verbose`

Changes:
- Remove inverted non-verbose branch and unused `deletedCount` in `cmd/backup.go`
- Gate all manifest display lines behind verbose flag in `cmd/verify.go`
- Update `agent_prompt.md` with bug fix entry and decision log
