### PR TITLE
feat: wire progress bars into pipelines for --verbose mode

### DIFF
--- a/agent_prompt.md
+++ b/agent_prompt.md
@@ -57,10 +57,11 @@
 
 ### ✅ Phase 5: User Experience (COMPLETE)
 
-**Phase 5.1: Silent by Default + Progress** ✅ (2026-02-08)
+**Phase 5.1: Silent by Default + Progress** ✅ (2026-02-08, wired 2026-02-15)
 - `internal/progress` package (ProgressReader/Writer)
 - Unix philosophy: silent success, errors to stderr
 - `--verbose` flag for progress and details
+- Progress bars wired into: backup, restore, verify pipelines + checksum compute/validate
 - Test coverage: 90% for progress package
 
 **Phase 5.1b: Test Coverage Improvements** ✅ (2026-02-07)
@@ -855,6 +856,7 @@ Example: `backup_documents_20260207_165324.tar.gz.gpg`
 | 2026-02-15 | Cobra completion disabled | `CompletionOptions.DisableDefaultCmd = true` on root command. Can be re-enabled later if needed. |
 | 2026-02-15 | Retention changed from days to count ([#27](https://github.com/icemarkom/secure-backup/issues/27)) | `--retention N` now means "keep last N backups" instead of "delete backups older than N days." Count-based retention works correctly regardless of backup frequency (hourly, daily, weekly). `DefaultKeepLast = 0` constant in `internal/retention`. |
 | 2026-02-15 | Silent-by-default fix ([#29](https://github.com/icemarkom/secure-backup/issues/29)) | Fixed 2 violations: (1) `cmd/backup.go` retention message used inverted `!backupVerbose` condition, (2) `cmd/verify.go` manifest/checksum display was ungated. All output now requires `--verbose` except `list`, `version`, dry-run, and stderr warnings. |
+| 2026-02-15 | Progress bars wired ([#31](https://github.com/icemarkom/secure-backup/issues/31)) | Connected existing `internal/progress` package to 5 operations: backup pipeline (tar reader), restore pipeline (file reader), full verify (file reader), checksum compute, checksum validate. All gated on `--verbose`. Added `ComputeChecksumProgress` / `ValidateChecksumProgress` to manifest package. |
 
 ---
 

--- a/cmd/backup.go
+++ b/cmd/backup.go
@@ -12,6 +12,7 @@ import (
 	"github.com/icemarkom/secure-backup/internal/errors"
 	"github.com/icemarkom/secure-backup/internal/lock"
 	"github.com/icemarkom/secure-backup/internal/manifest"
+	"github.com/icemarkom/secure-backup/internal/progress"
 	"github.com/icemarkom/secure-backup/internal/retention"
 	"github.com/spf13/cobra"
 )
@@ -158,7 +159,10 @@ func generateManifest(backupPath, sourcePath string, verbose bool, fileMode *os.
 	}
 
 	// Compute checksum
-	checksum, err := manifest.ComputeChecksum(backupPath)
+	checksum, err := manifest.ComputeChecksumProgress(backupPath, progress.Config{
+		Description: "Computing checksum",
+		Enabled:     verbose,
+	})
 	if err != nil {
 		return fmt.Errorf("failed to compute checksum: %w", err)
 	}

--- a/cmd/restore.go
+++ b/cmd/restore.go
@@ -9,6 +9,7 @@ import (
 	"github.com/icemarkom/secure-backup/internal/errors"
 	"github.com/icemarkom/secure-backup/internal/manifest"
 	"github.com/icemarkom/secure-backup/internal/passphrase"
+	"github.com/icemarkom/secure-backup/internal/progress"
 	"github.com/spf13/cobra"
 )
 
@@ -136,7 +137,10 @@ func validateManifest(backupFile string, verbose bool) error {
 			"The manifest may be corrupted. Use --skip-manifest to bypass (not recommended)")
 	}
 
-	if err := m.ValidateChecksum(backupFile); err != nil {
+	if err := m.ValidateChecksumProgress(backupFile, progress.Config{
+		Description: "Validating checksum",
+		Enabled:     verbose,
+	}); err != nil {
 		return errors.New(
 			"Backup file checksum mismatch",
 			"File may be corrupted. Use --skip-manifest to bypass (not recommended)",

--- a/cmd/verify.go
+++ b/cmd/verify.go
@@ -10,6 +10,7 @@ import (
 	"github.com/icemarkom/secure-backup/internal/format"
 	"github.com/icemarkom/secure-backup/internal/manifest"
 	"github.com/icemarkom/secure-backup/internal/passphrase"
+	"github.com/icemarkom/secure-backup/internal/progress"
 	"github.com/spf13/cobra"
 )
 
@@ -150,7 +151,10 @@ func validateAndDisplayManifest(backupFile string, verbose bool) (*manifest.Mani
 		)
 	}
 
-	if err := m.ValidateChecksum(backupFile); err != nil {
+	if err := m.ValidateChecksumProgress(backupFile, progress.Config{
+		Description: "Validating checksum",
+		Enabled:     verbose,
+	}); err != nil {
 		return nil, errors.New(
 			"Backup file checksum mismatch",
 			"File may be corrupted",


### PR DESCRIPTION
## Summary

Connect existing `internal/progress` package to 5 long-running operations when `--verbose` is set.

Fixes #31

## Changes

### Pipeline Progress
- **Backup**: wrap tar reader with progress bar, track source directory size
- **Restore**: wrap encrypted file reader, track file size
- **Full verify**: wrap file reader, replaces static status prints

### Checksum Progress
- New `ComputeChecksumProgress()` / `ValidateChecksumProgress()` in manifest package
- Callers in `cmd/backup.go`, `cmd/restore.go`, `cmd/verify.go` updated

## Behavior
- All progress bars gated on `--verbose` (silent by default)
- Output to stderr (Unix convention)
- Determinate bars with byte counts when size is known

## Testing
- `go build ./...` ✅
- `go test ./...` ✅ (all packages pass, no regressions)
- Manual testing with 50MB file confirmed progress bars work correctly