### PR TITLE
feat: add --compression none (passthrough)

### DIFF
--- a/internal/compress/compress.go
+++ b/internal/compress/compress.go
@@ -28,11 +28,14 @@ type Method int
 const (
 	// Gzip is the gzip compression method (using pgzip for parallelism).
 	Gzip Method = iota
+	// None disables compression (passthrough).
+	None
 )
 
 // String names for compression methods, used in CLI flags and user-facing output.
 const (
 	MethodGzip = "gzip"
+	MethodNone = "none"
 )
 
 // String returns the lowercase name of the compression method.
@@ -40,6 +43,8 @@ func (m Method) String() string {
 	switch m {
 	case Gzip:
 		return MethodGzip
+	case None:
+		return MethodNone
 	default:
 		return fmt.Sprintf("unknown(%d)", int(m))
 	}
@@ -47,7 +52,7 @@ func (m Method) String() string {
 
 // ValidMethods returns all supported compression methods.
 func ValidMethods() []Method {
-	return []Method{Gzip}
+	return []Method{Gzip, None}
 }
 
 // ValidMethodNames returns a comma-separated string of valid method names.
@@ -66,6 +71,8 @@ func ParseMethod(s string) (Method, error) {
 	switch strings.ToLower(s) {
 	case MethodGzip:
 		return Gzip, nil
+	case MethodNone:
+		return None, nil
 	default:
 		return 0, fmt.Errorf("unknown compression method: %s", s)
 	}
@@ -97,6 +104,8 @@ func NewCompressor(cfg Config) (Compressor, error) {
 	switch cfg.Method {
 	case Gzip:
 		return NewGzipCompressor(cfg.Level)
+	case None:
+		return NewNoopCompressor(), nil
 	default:
 		return nil, fmt.Errorf("unknown compression method: %s", cfg.Method)
 	}

--- a/internal/compress/compress_test.go
+++ b/internal/compress/compress_test.go
@@ -30,6 +30,7 @@ func TestMethod_String(t *testing.T) {
 		want   string
 	}{
 		{"Gzip", Gzip, "gzip"},
+		{"None", None, "none"},
 		{"unknown", Method(99), "unknown(99)"},
 	}
 
@@ -48,8 +49,11 @@ func TestParseMethod(t *testing.T) {
 		wantErr bool
 	}{
 		{"gzip lowercase", "gzip", Gzip, false},
+		{"none lowercase", "none", None, false},
 		{"GZIP uppercase", "GZIP", Gzip, false},
+		{"NONE uppercase", "NONE", None, false},
 		{"Gzip mixed case", "Gzip", Gzip, false},
+		{"None mixed case", "None", None, false},
 		{"unknown method", "bzip2", Method(0), true},
 		{"empty string", "", Method(0), true},
 	}
@@ -70,14 +74,16 @@ func TestParseMethod(t *testing.T) {
 
 func TestValidMethods(t *testing.T) {
 	methods := ValidMethods()
-	assert.Len(t, methods, 1)
+	assert.Len(t, methods, 2)
 	assert.Contains(t, methods, Gzip)
+	assert.Contains(t, methods, None)
 }
 
 func TestValidMethodNames(t *testing.T) {
 	names := ValidMethodNames()
 	assert.Contains(t, names, MethodGzip)
-	assert.Equal(t, "gzip", names)
+	assert.Contains(t, names, MethodNone)
+	assert.Equal(t, "gzip, none", names)
 }
 
 func TestGzipCompressor_Type(t *testing.T) {

--- a/internal/compress/noop.go
+++ b/internal/compress/noop.go
@@ -1,0 +1,48 @@
+// Copyright 2026 Marko Milivojevic
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package compress
+
+import "io"
+
+// NoopCompressor is a passthrough compressor that performs no compression.
+// It implements the Compressor interface with identity transforms.
+type NoopCompressor struct{}
+
+// NewNoopCompressor creates a new passthrough compressor.
+func NewNoopCompressor() *NoopCompressor {
+	return &NoopCompressor{}
+}
+
+// Compress returns the input stream unchanged.
+func (c *NoopCompressor) Compress(input io.Reader) (io.Reader, error) {
+	return input, nil
+}
+
+// Decompress returns the input stream unchanged.
+func (c *NoopCompressor) Decompress(input io.Reader) (io.Reader, error) {
+	return input, nil
+}
+
+// Type returns None.
+func (c *NoopCompressor) Type() Method {
+	return None
+}
+
+// Extension returns an empty string since no compression suffix is needed.
+func (c *NoopCompressor) Extension() string {
+	return ""
+}

--- a/internal/compress/noop_test.go
+++ b/internal/compress/noop_test.go
@@ -1,0 +1,89 @@
+// Copyright 2026 Marko Milivojevic
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package compress
+
+import (
+	"bytes"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNoopCompressor_Type(t *testing.T) {
+	compressor := NewNoopCompressor()
+	assert.Equal(t, None, compressor.Type())
+}
+
+func TestNoopCompressor_Extension(t *testing.T) {
+	compressor := NewNoopCompressor()
+	assert.Equal(t, "", compressor.Extension())
+}
+
+func TestNoopCompressor_RoundTrip(t *testing.T) {
+	compressor := NewNoopCompressor()
+	input := []byte("hello world - this data should pass through unchanged")
+
+	// Compress (passthrough)
+	compressed, err := compressor.Compress(bytes.NewReader(input))
+	require.NoError(t, err)
+
+	compressedData, err := io.ReadAll(compressed)
+	require.NoError(t, err)
+	assert.Equal(t, input, compressedData, "compressed data should equal input (passthrough)")
+
+	// Decompress (passthrough)
+	decompressed, err := compressor.Decompress(bytes.NewReader(compressedData))
+	require.NoError(t, err)
+
+	decompressedData, err := io.ReadAll(decompressed)
+	require.NoError(t, err)
+	assert.Equal(t, input, decompressedData, "decompressed data should equal input (passthrough)")
+}
+
+func TestNoopCompressor_LargeData(t *testing.T) {
+	compressor := NewNoopCompressor()
+	input := bytes.Repeat([]byte("large block of data "), 10000)
+
+	compressed, err := compressor.Compress(bytes.NewReader(input))
+	require.NoError(t, err)
+
+	result, err := io.ReadAll(compressed)
+	require.NoError(t, err)
+	assert.Equal(t, len(input), len(result), "passthrough should not change data size")
+	assert.Equal(t, input, result)
+}
+
+func TestNoopCompressor_EmptyInput(t *testing.T) {
+	compressor := NewNoopCompressor()
+
+	compressed, err := compressor.Compress(bytes.NewReader(nil))
+	require.NoError(t, err)
+
+	result, err := io.ReadAll(compressed)
+	require.NoError(t, err)
+	assert.Empty(t, result)
+}
+
+func TestNewCompressor_None(t *testing.T) {
+	compressor, err := NewCompressor(Config{Method: None})
+	require.NoError(t, err)
+	require.NotNil(t, compressor)
+	assert.Equal(t, None, compressor.Type())
+	assert.Equal(t, "", compressor.Extension())
+}

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -35,6 +35,8 @@ var knownBackupExtensions = []string{
 	".tar.gz.gpg",
 	".tar.zst.gpg",
 	".tar.gz.age",
+	".tar.gpg",
+	".tar.age",
 }
 
 // ManifestPath returns the manifest file path for a given backup file path.


### PR DESCRIPTION
## Summary

Adds `--compression none` option to skip compression entirely.

### Changes

- `None` Method constant + `MethodNone` string constant in `compress.go`
- `NoopCompressor` in `noop.go` — identity `Compress()`/`Decompress()`, empty `Extension()`
- Filenames become `.tar.gpg` / `.tar.age` (no compression suffix)
- `.tar.gpg` and `.tar.age` added to `knownBackupExtensions` in `manifest.go`
- 6 dedicated noop tests in `noop_test.go`
- Updated `compress_test.go` for None in ParseMethod, String, ValidMethods

Fixes #40