### PR TITLE
feat: --compression none with dynamic extension scaffolding (#40)

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -47,7 +47,7 @@ func init() {
 
 func runList(cmd *cobra.Command, args []string) error {
 	cmd.SilenceUsage = true
-	backups, err := retention.ListBackups(listDir, "")
+	backups, err := retention.ListBackups(listDir, "backup_*")
 	if err != nil {
 		return fmt.Errorf("failed to list backups: %w", err)
 	}

--- a/cmd/restore.go
+++ b/cmd/restore.go
@@ -96,9 +96,15 @@ func runRestore(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// Create compressor (gzip - should match backup)
+	// Auto-detect compression method from backup filename
+	compMethod, err := compress.ResolveMethod(restoreFile)
+	if err != nil {
+		return errors.Wrap(err, "Failed to detect compression method",
+			"Check that the backup file has a recognized extension (.tar.gz.gpg, .tar.gpg, etc.)")
+	}
+
 	compressor, err := compress.NewCompressor(compress.Config{
-		Method: compress.Gzip,
+		Method: compMethod,
 		Level:  0,
 	})
 	if err != nil {

--- a/cmd/verify.go
+++ b/cmd/verify.go
@@ -118,9 +118,15 @@ func runVerify(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	// Create compressor
+	// Auto-detect compression method from backup filename
+	compMethod, err := compress.ResolveMethod(verifyFile)
+	if err != nil {
+		return errors.Wrap(err, "Failed to detect compression method",
+			"Check that the backup file has a recognized extension (.tar.gz.gpg, .tar.gpg, etc.)")
+	}
+
 	compressor, err := compress.NewCompressor(compress.Config{
-		Method: compress.Gzip,
+		Method: compMethod,
 		Level:  0,
 	})
 	if err != nil {

--- a/internal/backup/backup.go
+++ b/internal/backup/backup.go
@@ -233,10 +233,12 @@ func dryRunBackup(cfg Config) (string, error) {
 	fmt.Printf("[DRY RUN]   Encryption: %s\n", encType)
 	fmt.Println("[DRY RUN]")
 	fmt.Println("[DRY RUN] Pipeline stages that would execute:")
-	fmt.Println("[DRY RUN]   1. TAR - Archive source directory")
-	fmt.Printf("[DRY RUN]   2. COMPRESS - Compress with %s\n", cfg.Compressor.Type())
-	fmt.Printf("[DRY RUN]   3. ENCRYPT - Encrypt with %s\n", encType)
-	fmt.Println("[DRY RUN]   4. WRITE - Write to destination file")
+	fmt.Println("[DRY RUN]   - TAR - Archive source directory")
+	if cfg.Compressor.Type() != compress.None {
+		fmt.Printf("[DRY RUN]   - COMPRESS - Compress with %s\n", cfg.Compressor.Type())
+	}
+	fmt.Printf("[DRY RUN]   - ENCRYPT - Encrypt with %s\n", encType)
+	fmt.Println("[DRY RUN]   - WRITE - Write to destination file")
 
 	return outputPath, nil
 }

--- a/internal/backup/restore.go
+++ b/internal/backup/restore.go
@@ -155,9 +155,11 @@ func dryRunRestore(cfg RestoreConfig) error {
 	fmt.Printf("[DRY RUN]   Destination: %s\n", cfg.DestPath)
 	fmt.Println("[DRY RUN]")
 	fmt.Println("[DRY RUN] Pipeline stages that would execute:")
-	fmt.Println("[DRY RUN]   1. DECRYPT - Decrypt backup file with GPG")
-	fmt.Println("[DRY RUN]   2. DECOMPRESS - Decompress with gzip")
-	fmt.Println("[DRY RUN]   3. EXTRACT - Extract tar archive to destination")
+	fmt.Printf("[DRY RUN]   - DECRYPT - Decrypt backup file with %s\n", cfg.Encryptor.Type())
+	if cfg.Compressor.Type() != compress.None {
+		fmt.Printf("[DRY RUN]   - DECOMPRESS - Decompress with %s\n", cfg.Compressor.Type())
+	}
+	fmt.Println("[DRY RUN]   - EXTRACT - Extract tar archive to destination")
 
 	return nil
 }

--- a/internal/backup/verify.go
+++ b/internal/backup/verify.go
@@ -182,9 +182,11 @@ func dryRunVerify(cfg VerifyConfig) error {
 		fmt.Printf("[DRY RUN]   Mode: Full verification (decrypt + decompress)\n")
 		fmt.Println("[DRY RUN]")
 		fmt.Println("[DRY RUN] Full verification would:")
-		fmt.Println("[DRY RUN]   1. DECRYPT - Decrypt with GPG")
-		fmt.Println("[DRY RUN]   2. DECOMPRESS - Decompress with gzip")
-		fmt.Println("[DRY RUN]   3. VERIFY - Read entire archive to verify integrity")
+		fmt.Printf("[DRY RUN]   - DECRYPT - Decrypt with %s\n", cfg.Encryptor.Type())
+		if cfg.Compressor.Type() != compress.None {
+			fmt.Printf("[DRY RUN]   - DECOMPRESS - Decompress with %s\n", cfg.Compressor.Type())
+		}
+		fmt.Println("[DRY RUN]   - VERIFY - Read entire archive to verify integrity")
 	}
 
 	return nil

--- a/internal/compress/compress.go
+++ b/internal/compress/compress.go
@@ -19,6 +19,7 @@ package compress
 import (
 	"fmt"
 	"io"
+	"sort"
 	"strings"
 )
 
@@ -66,16 +67,60 @@ func ValidMethodNames() string {
 	return strings.Join(names, ", ")
 }
 
+// parseMap maps lowercase method name → Method, built at init from ValidMethods().
+var parseMap map[string]Method
+
+// resolvePattern maps a ".tar{ext}." substring to a compression Method.
+type resolvePattern struct {
+	pattern string
+	method  Method
+}
+
+// resolvePatterns is the set of filename patterns for detecting compression,
+// built at init from ValidMethods(). Sorted longest-first for correct matching
+// (e.g., ".tar.gz." matches before ".tar.").
+var resolvePatterns []resolvePattern
+
+func init() {
+	parseMap = make(map[string]Method)
+	for _, m := range ValidMethods() {
+		// Build parse map: method name → Method
+		parseMap[m.String()] = m
+
+		// Build resolve patterns: ".tar{ext}." → Method
+		comp, err := NewCompressor(Config{Method: m})
+		if err != nil {
+			continue
+		}
+		resolvePatterns = append(resolvePatterns, resolvePattern{
+			pattern: fmt.Sprintf(".tar%s.", comp.Extension()),
+			method:  m,
+		})
+	}
+	// Sort longest-first: more-specific patterns must match before shorter ones
+	sort.Slice(resolvePatterns, func(i, j int) bool {
+		return len(resolvePatterns[i].pattern) > len(resolvePatterns[j].pattern)
+	})
+}
+
 // ParseMethod converts a string to a Method. Returns an error for unknown methods.
 func ParseMethod(s string) (Method, error) {
-	switch strings.ToLower(s) {
-	case MethodGzip:
-		return Gzip, nil
-	case MethodNone:
-		return None, nil
-	default:
-		return 0, fmt.Errorf("unknown compression method: %s", s)
+	if m, ok := parseMap[strings.ToLower(s)]; ok {
+		return m, nil
 	}
+	return 0, fmt.Errorf("unknown compression method: %s", s)
+}
+
+// ResolveMethod detects the compression method from a backup filename.
+// It matches ".tar{ext}." patterns built from all supported compressor extensions.
+func ResolveMethod(filename string) (Method, error) {
+	lower := strings.ToLower(filename)
+	for _, rp := range resolvePatterns {
+		if strings.Contains(lower, rp.pattern) {
+			return rp.method, nil
+		}
+	}
+	return 0, fmt.Errorf("cannot detect compression method from filename: %s", filename)
 }
 
 // Compressor defines the interface for compression/decompression operations
@@ -105,7 +150,7 @@ func NewCompressor(cfg Config) (Compressor, error) {
 	case Gzip:
 		return NewGzipCompressor(cfg.Level)
 	case None:
-		return NewNoopCompressor(), nil
+		return NewNoneCompressor(), nil
 	default:
 		return nil, fmt.Errorf("unknown compression method: %s", cfg.Method)
 	}

--- a/internal/compress/compress_test.go
+++ b/internal/compress/compress_test.go
@@ -97,3 +97,34 @@ func TestNewCompressor_UnknownMethod(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unknown compression method")
 }
+
+func TestResolveMethod(t *testing.T) {
+	tests := []struct {
+		name     string
+		filename string
+		want     Method
+		wantErr  bool
+	}{
+		{"gzip gpg", "backup_test_20260101_120000.tar.gz.gpg", Gzip, false},
+		{"gzip age", "backup_test_20260101_120000.tar.gz.age", Gzip, false},
+		{"none gpg", "backup_test_20260101_120000.tar.gpg", None, false},
+		{"none age", "backup_test_20260101_120000.tar.age", None, false},
+		{"full path gzip", "/backups/daily/backup_data.tar.gz.gpg", Gzip, false},
+		{"full path none", "/backups/daily/backup_data.tar.gpg", None, false},
+		{"unknown extension", "backup.zip", Method(0), true},
+		{"no extension", "backup", Method(0), true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ResolveMethod(tt.filename)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "cannot detect compression method")
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.want, got)
+			}
+		})
+	}
+}

--- a/internal/compress/none.go
+++ b/internal/compress/none.go
@@ -18,31 +18,31 @@ package compress
 
 import "io"
 
-// NoopCompressor is a passthrough compressor that performs no compression.
+// NoneCompressor is a passthrough compressor that performs no compression.
 // It implements the Compressor interface with identity transforms.
-type NoopCompressor struct{}
+type NoneCompressor struct{}
 
-// NewNoopCompressor creates a new passthrough compressor.
-func NewNoopCompressor() *NoopCompressor {
-	return &NoopCompressor{}
+// NewNoneCompressor creates a new passthrough compressor.
+func NewNoneCompressor() *NoneCompressor {
+	return &NoneCompressor{}
 }
 
 // Compress returns the input stream unchanged.
-func (c *NoopCompressor) Compress(input io.Reader) (io.Reader, error) {
+func (c *NoneCompressor) Compress(input io.Reader) (io.Reader, error) {
 	return input, nil
 }
 
 // Decompress returns the input stream unchanged.
-func (c *NoopCompressor) Decompress(input io.Reader) (io.Reader, error) {
+func (c *NoneCompressor) Decompress(input io.Reader) (io.Reader, error) {
 	return input, nil
 }
 
 // Type returns None.
-func (c *NoopCompressor) Type() Method {
+func (c *NoneCompressor) Type() Method {
 	return None
 }
 
 // Extension returns an empty string since no compression suffix is needed.
-func (c *NoopCompressor) Extension() string {
+func (c *NoneCompressor) Extension() string {
 	return ""
 }

--- a/internal/compress/none_test.go
+++ b/internal/compress/none_test.go
@@ -25,18 +25,18 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestNoopCompressor_Type(t *testing.T) {
-	compressor := NewNoopCompressor()
+func TestNoneCompressor_Type(t *testing.T) {
+	compressor := NewNoneCompressor()
 	assert.Equal(t, None, compressor.Type())
 }
 
-func TestNoopCompressor_Extension(t *testing.T) {
-	compressor := NewNoopCompressor()
+func TestNoneCompressor_Extension(t *testing.T) {
+	compressor := NewNoneCompressor()
 	assert.Equal(t, "", compressor.Extension())
 }
 
-func TestNoopCompressor_RoundTrip(t *testing.T) {
-	compressor := NewNoopCompressor()
+func TestNoneCompressor_RoundTrip(t *testing.T) {
+	compressor := NewNoneCompressor()
 	input := []byte("hello world - this data should pass through unchanged")
 
 	// Compress (passthrough)
@@ -56,8 +56,8 @@ func TestNoopCompressor_RoundTrip(t *testing.T) {
 	assert.Equal(t, input, decompressedData, "decompressed data should equal input (passthrough)")
 }
 
-func TestNoopCompressor_LargeData(t *testing.T) {
-	compressor := NewNoopCompressor()
+func TestNoneCompressor_LargeData(t *testing.T) {
+	compressor := NewNoneCompressor()
 	input := bytes.Repeat([]byte("large block of data "), 10000)
 
 	compressed, err := compressor.Compress(bytes.NewReader(input))
@@ -69,8 +69,8 @@ func TestNoopCompressor_LargeData(t *testing.T) {
 	assert.Equal(t, input, result)
 }
 
-func TestNoopCompressor_EmptyInput(t *testing.T) {
-	compressor := NewNoopCompressor()
+func TestNoneCompressor_EmptyInput(t *testing.T) {
+	compressor := NewNoneCompressor()
 
 	compressed, err := compressor.Compress(bytes.NewReader(nil))
 	require.NoError(t, err)

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -23,20 +23,36 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"sort"
 	"strings"
 	"time"
 
+	"github.com/icemarkom/secure-backup/internal/compress"
+	"github.com/icemarkom/secure-backup/internal/encrypt"
 	"github.com/icemarkom/secure-backup/internal/progress"
 )
 
-// knownBackupExtensions lists all recognized backup file extensions.
-// Order matters: longer/more-specific extensions should come first.
-var knownBackupExtensions = []string{
-	".tar.gz.gpg",
-	".tar.zst.gpg",
-	".tar.gz.age",
-	".tar.gpg",
-	".tar.age",
+// knownBackupExtensions lists all recognized backup file extensions,
+// built dynamically from supported compression and encryption methods.
+// Sorted longest-first so more-specific extensions match before shorter ones.
+var knownBackupExtensions []string
+
+func init() {
+	for _, c := range compress.ValidMethods() {
+		comp, err := compress.NewCompressor(compress.Config{Method: c})
+		if err != nil {
+			continue
+		}
+		for _, e := range encrypt.ValidMethods() {
+			knownBackupExtensions = append(knownBackupExtensions,
+				fmt.Sprintf(".tar%s.%s", comp.Extension(), e.Extension()))
+		}
+	}
+	// Sort longest-first: more-specific extensions must match before shorter ones
+	// (e.g., ".tar.gz.gpg" before ".tar.gpg")
+	sort.Slice(knownBackupExtensions, func(i, j int) bool {
+		return len(knownBackupExtensions[i]) > len(knownBackupExtensions[j])
+	})
 }
 
 // ManifestPath returns the manifest file path for a given backup file path.
@@ -73,7 +89,7 @@ type CreatedBy struct {
 }
 
 // New creates a new manifest with the given parameters
-func New(sourcePath, backupFile, version string) (*Manifest, error) {
+func New(sourcePath, backupFile, version, compression, encryption string) (*Manifest, error) {
 	hostname, err := os.Hostname()
 	if err != nil {
 		// Graceful fallback
@@ -84,8 +100,8 @@ func New(sourcePath, backupFile, version string) (*Manifest, error) {
 		CreatedAt:         time.Now().UTC(),
 		SourcePath:        sourcePath,
 		BackupFile:        backupFile,
-		Compression:       "gzip",
-		Encryption:        "gpg",
+		Compression:       compression,
+		Encryption:        encryption,
 		ChecksumAlgorithm: "sha256",
 		ChecksumValue:     "", // Set later via ComputeChecksum
 		SizeBytes:         0,  // Set later


### PR DESCRIPTION
## Summary

Wire `--compression none` flag end-to-end and eliminate all hardcoded extension strings, creating an expandable scaffolding for future compression methods.

### Changes (19 files, +455/-159)

**New files:**
- `internal/compress/none.go` — `NoneCompressor` (identity passthrough)
- `internal/compress/none_test.go` — 6 unit tests

**Core wiring:**
- `cmd/backup.go` — `--compression` flag (default: gzip), dynamic retention pattern
- `cmd/restore.go` / `cmd/verify.go` — auto-detect compression via `compress.ResolveMethod()`
- `internal/backup/*.go` — dry-run output uses bullets, skips DECOMPRESS when none
- `internal/manifest/manifest.go` — `manifest.New()` accepts compression/encryption names

**Hardcoding elimination:**
- `compress.go` — `ParseMethod()` and `ResolveMethod()` use init-time lookup tables built from `ValidMethods()`
- `manifest.go` — `knownBackupExtensions` built from compress × encrypt cross-product
- `policy.go` — `validBackupExtensions` and `IsBackupFile()` built dynamically; empty pattern errors instead of defaulting
- `cmd/list.go` — uses `backup_*` glob with `IsBackupFile()` post-filtering
- Removed phantom `.tar.zst.gpg` (zstd not implemented)

**To add a new compression method, you only need to:**
1. Add the `Method` const and string name
2. Add it to `ValidMethods()`
3. Implement the `Compressor` interface

Everything else auto-wires: CLI parsing, filename detection, backup validation, manifest paths, retention patterns.

### Testing
- Unit: `TestResolveMethod` (8 cases), `TestParseMethod` (8 cases), `TestIsBackupFile` (9 cases)
- E2E: full `--compression none` pipeline (backup → verify → restore → diff)

Closes #40
Ref #15