### PR TITLE
feat: add cron.daily example script for automated backups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 # Binaries
 backup-docker
-secure-backup
+/secure-backup
 *.exe
 
 # Test artifacts

--- a/agent_prompt.md
+++ b/agent_prompt.md
@@ -563,6 +563,7 @@ secure-backup/
 │   ├── passphrase/        # Secure passphrase handling (flag/env/file)
 │   ├── progress/          # Progress tracking
 │   └── retention/         # Retention management
+├── examples/              # Usage examples (cron.daily script)
 ├── test-scripts/          # Test scripts (key generation, E2E)
 ├── test_data/             # Generated test data (keys, gitignored)
 ├── main.go                # Entry point
@@ -892,6 +893,7 @@ Example: `backup_documents_20260207_165324.tar.gz.gpg`
 | 2026-02-16 | Filed manifest-first management issue ([#45](https://github.com/icemarkom/secure-backup/issues/45)) | Manifested backups as first-class citizens, non-manifested as orphans. Affects list, verify, retention. Future enhancement. |
 | 2026-02-16 | Standardized IO buffer size ([#47](https://github.com/icemarkom/secure-backup/issues/47)) | Created shared `IOBufferSize = 1 MiB` const. Replaced all pipeline `io.Copy` calls with `io.CopyBuffer(... common.NewBuffer())` across 8 files (11 call sites). Benchmarked 32KB–4MB; 1MiB chosen for syscall reduction on disk IO. |
 | 2026-02-16 | Consolidated helper packages ([#48](https://github.com/icemarkom/secure-backup/issues/48)) | Merged `internal/format`, `internal/ioutil`, `internal/errors` into `internal/common`. All shared utility functions (formatting, IO buffers, user-friendly errors) live in one package. `internal/progress` kept separate (external dep). **Ongoing: all new shared helpers go in `internal/common`.** |
+| 2026-02-17 | Cron.daily example script ([#50](https://github.com/icemarkom/secure-backup/pull/50)) | Added `examples/cron.daily/secure-backup` — drop-in script for `/etc/cron.daily/` on Ubuntu. Supports multiple source directories via bash array, configurable AGE/GPG encryption, retention, logging, and per-source failure tracking. `.gitignore` scoped `secure-backup` → `/secure-backup` to avoid ignoring the example. |
 
 ---
 
@@ -964,8 +966,8 @@ make license-check
 
 ---
 
-**Last Updated**: 2026-02-16  
-**Last Updated By**: Agent (conversation 4b6e349d-cbed-4968-b469-26afdf65d80d)  
+**Last Updated**: 2026-02-17  
+**Last Updated By**: Agent (conversation 597017f6-d83e-4dca-a2e8-c34f4d358dcf)  
 **Current Release**: v1.1.3  
 **Project Phase**: Post-1.0 improvements ✅  
 **Production Trust Score**: 7.5/10 — All productionization items resolved  

--- a/examples/cron.daily/secure-backup
+++ b/examples/cron.daily/secure-backup
@@ -1,0 +1,65 @@
+#!/bin/bash
+# /etc/cron.daily/secure-backup
+#
+# Daily encrypted backup using secure-backup with AGE or GPG encryption.
+# Runs automatically via anacron/cron.daily on Ubuntu.
+#
+# Install:
+#   sudo cp secure-backup /etc/cron.daily/secure-backup
+#   sudo chmod 755 /etc/cron.daily/secure-backup
+#   sudo ${EDITOR:?Set EDITOR variable} /etc/cron.daily/secure-backup  # set SOURCES, DEST, ENCRYPTION, PUBLIC_KEY
+#
+# Test:
+#   sudo run-parts --test /etc/cron.daily/
+#   sudo /etc/cron.daily/secure-backup
+
+set -eu
+
+# ── Configuration ─────────────────────────────────────────────
+SOURCES=(
+  "/path/to/data1"
+  "/path/to/data2"
+  "/path/to/data3"
+)
+DEST="/path/to/backups"
+ENCRYPTION="age"
+PUBLIC_KEY="age1yourpublickeyhere"
+RETENTION=7
+LOG="/var/log/secure-backup.log"
+# ──────────────────────────────────────────────────────────────
+
+SECURE_BACKUP="/usr/bin/secure-backup"
+FAILED=0
+
+if [ ! -x "${SECURE_BACKUP}" ]; then
+  echo "$(date -Iseconds) secure-backup binary not found at ${SECURE_BACKUP}" >&2
+  exit 1
+fi
+
+for SOURCE in "${SOURCES[@]}"; do
+  if [ ! -d "${SOURCE}" ]; then
+    echo "$(date -Iseconds) source directory not found: ${SOURCE}" >&2
+    FAILED=$((FAILED + 1))
+    continue
+  fi
+
+  echo "$(date -Iseconds) Starting backup: ${SOURCE} -> ${DEST}" >> "${LOG}"
+
+  if "${SECURE_BACKUP}" backup \
+      --source "${SOURCE}" \
+      --dest "${DEST}" \
+      --encryption "${ENCRYPTION}" \
+      --public-key "${PUBLIC_KEY}" \
+      --retention "${RETENTION}" \
+      2>> "${LOG}"; then
+    echo "$(date -Iseconds) Backup completed: ${SOURCE}" >> "${LOG}"
+  else
+    echo "$(date -Iseconds) BACKUP FAILED: ${SOURCE} (exit code $?)" >> "${LOG}"
+    FAILED=$((FAILED + 1))
+  fi
+done
+
+if [ "${FAILED}" -gt 0 ]; then
+  echo "secure-backup: ${FAILED}/${#SOURCES[@]} backup(s) failed. See ${LOG}" >&2
+  exit 1
+fi


### PR DESCRIPTION
Adds an example cron.daily script for automated AGE/GPG encrypted backups on Ubuntu.

**Changes:**
- `examples/cron.daily/secure-backup` — drop-in script for `/etc/cron.daily/`
  - Supports multiple source directories via SOURCES array
  - Configurable encryption method (AGE or GPG)
  - Retention management, logging, and failure reporting
- `.gitignore` — scoped `secure-backup` → `/secure-backup` so the binary ignore only applies at root