### PR TITLE
feat: track uncompressed and compressed sizes in manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,12 +346,13 @@ Each backup creates two files:
   "backup_file": "backup_documents_20260214_183000.tar.gz.gpg",
   "checksum_algorithm": "sha256",
   "checksum_value": "abc123def456...",
-  "size_bytes": 523400000,
+  "uncompressed_size_bytes": 1073741824,
+  "compressed_size_bytes": 523400000,
   "compression": "gzip",
   "encryption": "gpg",
   "created_by": {
     "tool": "secure-backup",
-    "version": "v0.2.0",
+    "version": "v1.2.0",
     "hostname": "myserver"
   }
 }

--- a/agent_prompt.md
+++ b/agent_prompt.md
@@ -119,17 +119,20 @@
 **Manifest Format**:
 ```json
 {
-  "version": "1.0.0",
-  "created": "2026-02-08T22:30:00Z",
-  "source": "/path/to/source",
-  "backup_file": "backup_source_20260208_223000.tar.gz.gpg",
-  "checksum": {
-    "algorithm": "sha256",
-    "value": "abc123..."
+  "created_at": "2026-02-08T22:30:00Z",
+  "created_by": {
+    "tool": "secure-backup",
+    "version": "v1.2.0",
+    "hostname": "myserver"
   },
+  "source_path": "/path/to/source",
+  "backup_file": "backup_source_20260208_223000.tar.gz.gpg",
   "compression": "gzip",
   "encryption": "gpg",
-  "tool_version": "v0.1.0"
+  "checksum_algorithm": "sha256",
+  "checksum_value": "abc123...",
+  "uncompressed_size_bytes": 1073741824,
+  "compressed_size_bytes": 523400000
 }
 ```
 
@@ -894,6 +897,7 @@ Example: `backup_documents_20260207_165324.tar.gz.gpg`
 | 2026-02-16 | Standardized IO buffer size ([#47](https://github.com/icemarkom/secure-backup/issues/47)) | Created shared `IOBufferSize = 1 MiB` const. Replaced all pipeline `io.Copy` calls with `io.CopyBuffer(... common.NewBuffer())` across 8 files (11 call sites). Benchmarked 32KB–4MB; 1MiB chosen for syscall reduction on disk IO. |
 | 2026-02-16 | Consolidated helper packages ([#48](https://github.com/icemarkom/secure-backup/issues/48)) | Merged `internal/format`, `internal/ioutil`, `internal/errors` into `internal/common`. All shared utility functions (formatting, IO buffers, user-friendly errors) live in one package. `internal/progress` kept separate (external dep). **Ongoing: all new shared helpers go in `internal/common`.** |
 | 2026-02-17 | Cron.daily example script ([#50](https://github.com/icemarkom/secure-backup/pull/50)) | Added `examples/cron.daily/secure-backup` — drop-in script for `/etc/cron.daily/` on Ubuntu. Supports multiple source directories via bash array, configurable AGE/GPG encryption, retention, logging, and per-source failure tracking. `.gitignore` scoped `secure-backup` → `/secure-backup` to avoid ignoring the example. |
+| 2026-02-17 | Manifest size fields ([#51](https://github.com/icemarkom/secure-backup/issues/51)) | Renamed `size_bytes` → `compressed_size_bytes`, added `uncompressed_size_bytes`. Uncompressed size counted inside `CreateTar` as raw file data bytes (no tar headers, no TOCTOU). `CreateTar` returns `(int64, error)`, plumbed through `executePipeline` → `PerformBackup` → manifest. `getDirectorySize()` remains for progress bar estimate only. |
 
 ---
 

--- a/cmd/verify.go
+++ b/cmd/verify.go
@@ -227,7 +227,10 @@ func validateAndDisplayManifest(backupFile string, verbose bool) (*manifest.Mani
 			m.CreatedAt.Format("2006-01-02 15:04:05"),
 			m.CreatedBy.Tool, m.CreatedBy.Version, m.CreatedBy.Hostname)
 		fmt.Printf("Source:   %s\n", m.SourcePath)
-		fmt.Printf("Size:     %s\n", common.Size(m.SizeBytes))
+		if m.UncompressedSizeBytes > 0 {
+			fmt.Printf("Uncompressed size: %s\n", common.Size(m.UncompressedSizeBytes))
+		}
+		fmt.Printf("Compressed size:   %s\n", common.Size(m.CompressedSizeBytes))
 	}
 
 	return m, nil

--- a/internal/archive/tar_test.go
+++ b/internal/archive/tar_test.go
@@ -37,8 +37,9 @@ func TestCreateTar_SingleFile(t *testing.T) {
 
 	// Create tar
 	var buf bytes.Buffer
-	err = CreateTar(testFile, &buf)
+	bytesWritten, err := CreateTar(testFile, &buf)
 	require.NoError(t, err)
+	assert.Equal(t, int64(len(testContent)), bytesWritten)
 
 	// Verify tar was created
 	assert.Greater(t, buf.Len(), 0)
@@ -65,8 +66,11 @@ func TestCreateTar_Directory(t *testing.T) {
 
 	// Create tar
 	var buf bytes.Buffer
-	err = CreateTar(tmpDir, &buf)
+	bytesWritten, err := CreateTar(tmpDir, &buf)
 	require.NoError(t, err)
+
+	// 3 files: "content1" (8) + "content2" (8) + "content3" (8) = 24 bytes
+	assert.Equal(t, int64(24), bytesWritten)
 
 	// Verify tar was created
 	assert.Greater(t, buf.Len(), 0)
@@ -74,7 +78,7 @@ func TestCreateTar_Directory(t *testing.T) {
 
 func TestCreateTar_InvalidPath(t *testing.T) {
 	var buf bytes.Buffer
-	err := CreateTar("/nonexistent/path/that/does/not/exist", &buf)
+	_, err := CreateTar("/nonexistent/path/that/does/not/exist", &buf)
 	assert.Error(t, err)
 }
 
@@ -108,7 +112,7 @@ func TestExtractTar_RoundTrip(t *testing.T) {
 
 	// Create tar
 	var buf bytes.Buffer
-	err = CreateTar(srcDir, &buf)
+	_, err = CreateTar(srcDir, &buf)
 	require.NoError(t, err)
 
 	// Extract to new directory
@@ -168,7 +172,7 @@ func TestExtractTar_CreateDestination(t *testing.T) {
 	require.NoError(t, err)
 
 	var buf bytes.Buffer
-	err = CreateTar(testFile, &buf)
+	_, err = CreateTar(testFile, &buf)
 	require.NoError(t, err)
 
 	// Extract to nonexistent path
@@ -230,8 +234,11 @@ func TestCreateTar_Symlink(t *testing.T) {
 
 	// Create tar
 	var buf bytes.Buffer
-	err = CreateTar(tmpDir, &buf)
+	bytesWritten, err := CreateTar(tmpDir, &buf)
 	require.NoError(t, err)
+
+	// Only target.txt has file data (14 bytes), symlink has 0 data bytes
+	assert.Equal(t, int64(len("target content")), bytesWritten)
 
 	// Extract
 	destDir := t.TempDir()
@@ -270,7 +277,7 @@ func TestCreateTar_SymlinkToExternal(t *testing.T) {
 
 	// Create tar
 	var buf bytes.Buffer
-	err = CreateTar(srcDir, &buf)
+	_, err = CreateTar(srcDir, &buf)
 	require.NoError(t, err)
 
 	// Extract and verify the external file content was NOT included
@@ -312,7 +319,7 @@ func TestCreateTar_SymlinkRoundTrip(t *testing.T) {
 
 	// Backup
 	var buf bytes.Buffer
-	err = CreateTar(srcDir, &buf)
+	_, err = CreateTar(srcDir, &buf)
 	require.NoError(t, err)
 
 	// Restore

--- a/internal/backup/backup_test.go
+++ b/internal/backup/backup_test.go
@@ -118,7 +118,7 @@ func TestPerformBackup_InvalidSource(t *testing.T) {
 				Verbose:    false,
 			}
 
-			_, err = PerformBackup(context.Background(), cfg)
+			_, _, err = PerformBackup(context.Background(), cfg)
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), tt.wantErrMsg)
 		})
@@ -174,7 +174,7 @@ func TestPerformBackup_DestinationCreation(t *testing.T) {
 		Verbose:    false,
 	}
 
-	backupPath, err := PerformBackup(context.Background(), cfg)
+	backupPath, _, err := PerformBackup(context.Background(), cfg)
 	require.NoError(t, err)
 
 	// Verify destination directory was created
@@ -249,7 +249,7 @@ func TestPerformBackup_FilenameFormat(t *testing.T) {
 				Verbose:    false,
 			}
 
-			backupPath, err := PerformBackup(context.Background(), cfg)
+			backupPath, _, err := PerformBackup(context.Background(), cfg)
 			require.NoError(t, err)
 
 			filename := filepath.Base(backupPath)
@@ -354,7 +354,7 @@ func TestPerformBackup_DryRun(t *testing.T) {
 		DryRun:     true,
 	}
 
-	backupPath, err := PerformBackup(context.Background(), cfg)
+	backupPath, _, err := PerformBackup(context.Background(), cfg)
 	require.NoError(t, err)
 	assert.NotEmpty(t, backupPath, "should return expected backup path")
 
@@ -396,7 +396,7 @@ func TestPerformBackup_DryRun_InvalidSource(t *testing.T) {
 		DryRun:     true,
 	}
 
-	_, err = PerformBackup(context.Background(), cfg)
+	_, _, err = PerformBackup(context.Background(), cfg)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid source path")
 }
@@ -447,7 +447,7 @@ func TestPerformBackup_NoTempFilesOnSuccess(t *testing.T) {
 		Verbose:    false,
 	}
 
-	backupPath, err := PerformBackup(context.Background(), cfg)
+	backupPath, _, err := PerformBackup(context.Background(), cfg)
 	require.NoError(t, err)
 
 	// Verify final backup file exists
@@ -506,7 +506,7 @@ func TestPerformBackup_TempFileCleanupOnError(t *testing.T) {
 	}
 
 	// Backup should fail due to invalid key
-	_, err = PerformBackup(context.Background(), cfg)
+	_, _, err = PerformBackup(context.Background(), cfg)
 	require.Error(t, err)
 
 	// Verify no .tmp files remain in destination directory
@@ -580,7 +580,7 @@ func TestPerformBackup_FilePermissions_Default(t *testing.T) {
 		FileMode:   &mode,
 	}
 
-	backupPath, err := PerformBackup(context.Background(), cfg)
+	backupPath, _, err := PerformBackup(context.Background(), cfg)
 	require.NoError(t, err)
 
 	// Verify file permissions
@@ -638,7 +638,7 @@ func TestPerformBackup_FilePermissions_Custom(t *testing.T) {
 		FileMode:   &mode,
 	}
 
-	backupPath, err := PerformBackup(context.Background(), cfg)
+	backupPath, _, err := PerformBackup(context.Background(), cfg)
 	require.NoError(t, err)
 
 	// Verify file permissions

--- a/internal/backup/restore_test.go
+++ b/internal/backup/restore_test.go
@@ -127,7 +127,7 @@ func TestPerformRestore_DestinationCreation(t *testing.T) {
 		Verbose:    false,
 	}
 
-	backupPath, err := PerformBackup(context.Background(), backupCfg)
+	backupPath, _, err := PerformBackup(context.Background(), backupCfg)
 	require.NoError(t, err)
 
 	// Now restore to a nested destination path that doesn't exist
@@ -366,7 +366,7 @@ func TestPerformRestore_NonEmptyDestination_WithoutForce(t *testing.T) {
 		Verbose:    false,
 	}
 
-	backupPath, err := PerformBackup(context.Background(), backupCfg)
+	backupPath, _, err := PerformBackup(context.Background(), backupCfg)
 	require.NoError(t, err)
 
 	// Create non-empty restore destination
@@ -437,7 +437,7 @@ func TestPerformRestore_NonEmptyDestination_WithForce(t *testing.T) {
 		Verbose:    false,
 	}
 
-	backupPath, err := PerformBackup(context.Background(), backupCfg)
+	backupPath, _, err := PerformBackup(context.Background(), backupCfg)
 	require.NoError(t, err)
 
 	// Create non-empty restore destination
@@ -517,7 +517,7 @@ func TestPerformRestore_EmptyDestination_WithoutForce(t *testing.T) {
 		Verbose:    false,
 	}
 
-	backupPath, err := PerformBackup(context.Background(), backupCfg)
+	backupPath, _, err := PerformBackup(context.Background(), backupCfg)
 	require.NoError(t, err)
 
 	// Create empty restore destination
@@ -588,7 +588,7 @@ func TestPerformRestore_NonexistentDestination_WithoutForce(t *testing.T) {
 		Verbose:    false,
 	}
 
-	backupPath, err := PerformBackup(context.Background(), backupCfg)
+	backupPath, _, err := PerformBackup(context.Background(), backupCfg)
 	require.NoError(t, err)
 
 	// Don't create restore directory - it should be created automatically

--- a/internal/backup/verify_test.go
+++ b/internal/backup/verify_test.go
@@ -204,7 +204,7 @@ func TestFullVerify_WithRealBackup(t *testing.T) {
 		Verbose:    false,
 	}
 
-	backupPath, err := PerformBackup(context.Background(), backupCfg)
+	backupPath, _, err := PerformBackup(context.Background(), backupCfg)
 	require.NoError(t, err)
 
 	// Test quick verify

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -71,15 +71,16 @@ func ManifestPath(backupPath string) string {
 
 // Manifest represents metadata and integrity information for a backup
 type Manifest struct {
-	CreatedAt         time.Time `json:"created_at"`
-	CreatedBy         CreatedBy `json:"created_by"`
-	SourcePath        string    `json:"source_path"`
-	BackupFile        string    `json:"backup_file"`
-	Compression       string    `json:"compression"`
-	Encryption        string    `json:"encryption"`
-	ChecksumAlgorithm string    `json:"checksum_algorithm"`
-	ChecksumValue     string    `json:"checksum_value"`
-	SizeBytes         int64     `json:"size_bytes"`
+	CreatedAt             time.Time `json:"created_at"`
+	CreatedBy             CreatedBy `json:"created_by"`
+	SourcePath            string    `json:"source_path"`
+	BackupFile            string    `json:"backup_file"`
+	Compression           string    `json:"compression"`
+	Encryption            string    `json:"encryption"`
+	ChecksumAlgorithm     string    `json:"checksum_algorithm"`
+	ChecksumValue         string    `json:"checksum_value"`
+	UncompressedSizeBytes int64     `json:"uncompressed_size_bytes"`
+	CompressedSizeBytes   int64     `json:"compressed_size_bytes"`
 }
 
 // CreatedBy holds information about the tool that created the backup
@@ -98,14 +99,15 @@ func New(sourcePath, backupFile, version, compression, encryption string) (*Mani
 	}
 
 	return &Manifest{
-		CreatedAt:         time.Now().UTC(),
-		SourcePath:        sourcePath,
-		BackupFile:        backupFile,
-		Compression:       compression,
-		Encryption:        encryption,
-		ChecksumAlgorithm: "sha256",
-		ChecksumValue:     "", // Set later via ComputeChecksum
-		SizeBytes:         0,  // Set later
+		CreatedAt:             time.Now().UTC(),
+		SourcePath:            sourcePath,
+		BackupFile:            backupFile,
+		Compression:           compression,
+		Encryption:            encryption,
+		ChecksumAlgorithm:     "sha256",
+		ChecksumValue:         "", // Set later via ComputeChecksum
+		UncompressedSizeBytes: 0,  // Set later
+		CompressedSizeBytes:   0,  // Set later
 		CreatedBy: CreatedBy{
 			Tool:     "secure-backup",
 			Version:  version,

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -102,7 +102,8 @@ func TestWrite(t *testing.T) {
 	m, err := New("/test/source", "backup.tar.gz.gpg", "v1.0.0", "gzip", "gpg")
 	require.NoError(t, err)
 	m.ChecksumValue = "abc123"
-	m.SizeBytes = 1024
+	m.UncompressedSizeBytes = 4096
+	m.CompressedSizeBytes = 1024
 
 	err = m.Write(manifestPath, nil)
 	require.NoError(t, err)
@@ -116,6 +117,8 @@ func TestWrite(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, string(data), "\"source_path\": \"/test/source\"")
 	assert.Contains(t, string(data), "\"checksum_value\": \"abc123\"")
+	assert.Contains(t, string(data), "\"uncompressed_size_bytes\": 4096")
+	assert.Contains(t, string(data), "\"compressed_size_bytes\": 1024")
 }
 
 func TestRead(t *testing.T) {
@@ -126,7 +129,8 @@ func TestRead(t *testing.T) {
 	original, err := New("/test/source", "backup.tar.gz.gpg", "v1.0.0", "gzip", "gpg")
 	require.NoError(t, err)
 	original.ChecksumValue = "abc123"
-	original.SizeBytes = 2048
+	original.UncompressedSizeBytes = 8192
+	original.CompressedSizeBytes = 2048
 
 	err = original.Write(manifestPath, nil)
 	require.NoError(t, err)
@@ -140,7 +144,8 @@ func TestRead(t *testing.T) {
 	assert.Equal(t, original.SourcePath, m.SourcePath)
 	assert.Equal(t, original.BackupFile, m.BackupFile)
 	assert.Equal(t, original.ChecksumValue, m.ChecksumValue)
-	assert.Equal(t, original.SizeBytes, m.SizeBytes)
+	assert.Equal(t, original.CompressedSizeBytes, m.CompressedSizeBytes)
+	assert.Equal(t, original.UncompressedSizeBytes, m.UncompressedSizeBytes)
 	assert.Equal(t, original.CreatedBy.Tool, m.CreatedBy.Tool)
 	assert.Equal(t, original.CreatedBy.Version, m.CreatedBy.Version)
 }
@@ -153,7 +158,8 @@ func TestReadWrite_RoundTrip(t *testing.T) {
 	m1, err := New("/source/path", "backup_file.tar.gz.gpg", "v2.0.0", "gzip", "gpg")
 	require.NoError(t, err)
 	m1.ChecksumValue = "def456"
-	m1.SizeBytes = 4096
+	m1.UncompressedSizeBytes = 16384
+	m1.CompressedSizeBytes = 4096
 
 	// Write
 	err = m1.Write(manifestPath, nil)
@@ -170,7 +176,8 @@ func TestReadWrite_RoundTrip(t *testing.T) {
 	assert.Equal(t, m1.Encryption, m2.Encryption)
 	assert.Equal(t, m1.ChecksumAlgorithm, m2.ChecksumAlgorithm)
 	assert.Equal(t, m1.ChecksumValue, m2.ChecksumValue)
-	assert.Equal(t, m1.SizeBytes, m2.SizeBytes)
+	assert.Equal(t, m1.CompressedSizeBytes, m2.CompressedSizeBytes)
+	assert.Equal(t, m1.UncompressedSizeBytes, m2.UncompressedSizeBytes)
 	assert.Equal(t, m1.CreatedBy.Tool, m2.CreatedBy.Tool)
 	assert.Equal(t, m1.CreatedBy.Version, m2.CreatedBy.Version)
 	assert.Equal(t, m1.CreatedBy.Hostname, m2.CreatedBy.Hostname)
@@ -385,7 +392,7 @@ func TestWrite_NoTempFilesOnSuccess(t *testing.T) {
 	m, err := New("/test/source", "backup.tar.gz.gpg", "v1.0.0", "gzip", "gpg")
 	require.NoError(t, err)
 	m.ChecksumValue = "test123"
-	m.SizeBytes = 1024
+	m.CompressedSizeBytes = 1024
 
 	err = m.Write(manifestPath, nil)
 	require.NoError(t, err)
@@ -417,7 +424,7 @@ func TestWrite_FilePermissions(t *testing.T) {
 	m, err := New("/test/source", "backup.tar.gz.gpg", "v1.0.0", "gzip", "gpg")
 	require.NoError(t, err)
 	m.ChecksumValue = "abc123"
-	m.SizeBytes = 1024
+	m.CompressedSizeBytes = 1024
 
 	mode := os.FileMode(0600)
 	err = m.Write(manifestPath, &mode)

--- a/test-scripts/e2e_test.sh
+++ b/test-scripts/e2e_test.sh
@@ -147,6 +147,15 @@ MANIFEST_FILE=$(find "$BACKUP_DIR" -name "*_manifest.json" | head -1)
 test -n "$MANIFEST_FILE" || fail "No manifest file found"
 test -s "$MANIFEST_FILE" || fail "Manifest file is empty"
 
+# Verify manifest contains both size fields with positive values
+grep -q '"compressed_size_bytes":' "$MANIFEST_FILE" || fail "Manifest missing compressed_size_bytes"
+grep -q '"uncompressed_size_bytes":' "$MANIFEST_FILE" || fail "Manifest missing uncompressed_size_bytes"
+# Verify sizes are positive integers (not zero)
+COMPRESSED=$(grep -o '"compressed_size_bytes": [0-9]*' "$MANIFEST_FILE" | grep -o '[0-9]*$')
+UNCOMPRESSED=$(grep -o '"uncompressed_size_bytes": [0-9]*' "$MANIFEST_FILE" | grep -o '[0-9]*$')
+test "$COMPRESSED" -gt 0 || fail "compressed_size_bytes should be > 0, got $COMPRESSED"
+test "$UNCOMPRESSED" -gt 0 || fail "uncompressed_size_bytes should be > 0, got $UNCOMPRESSED"
+
 # Verify no leftover temp or lock files
 LEFTOVER_TMP=$(find "$BACKUP_DIR" -name "*.tmp" | wc -l | tr -d ' ')
 LEFTOVER_LOCK=$(find "$BACKUP_DIR" -name ".backup.lock" | wc -l | tr -d ' ')


### PR DESCRIPTION
Closes #51

## Changes

Adds two size fields to the manifest for tracking both raw source data and final backup sizes:
- **`uncompressed_size_bytes`** — raw file data bytes counted inside `CreateTar` (no tar headers, no TOCTOU)
- **`compressed_size_bytes`** — final encrypted backup file size (renamed from `size_bytes`)

### Implementation

- `CreateTar` returns `(int64, error)` — accumulates only `io.CopyBuffer` bytes (file data, not tar headers)
- `executePipeline` captures the count from the tar goroutine
- `PerformBackup` returns `(string, int64, error)` — passes uncompressed size to the manifest
- `getDirectorySize()` remains as a best-effort progress bar estimate

### Test Coverage

- **Manifest unit tests**: `UncompressedSizeBytes` in Write, Read, and RoundTrip assertions
- **Integration test**: asserts `PerformBackup` returns correct uncompressed size matching known input data
- **E2E test**: validates manifest JSON has both `compressed_size_bytes` and `uncompressed_size_bytes` > 0

### Files changed (14)

| Package | File | Change |
|---------|------|--------|
| archive | `tar.go` | Return `(int64, error)` with raw data bytes |
| archive | `tar_test.go` | Assert byte counts, update 8 call sites |
| manifest | `manifest.go` | Rename + add field |
| manifest | `manifest_test.go` | Add `UncompressedSizeBytes` roundtrip assertions |
| backup | `backup.go` | Plumb size through pipeline |
| backup | `*_test.go` (4 files) | Update ~21 call sites |
| backup | `integration_test.go` | Assert uncompressed size matches input |
| cmd | `backup.go` | Wire to manifest |
| cmd | `verify.go` | Display both sizes |
| e2e | `e2e_test.sh` | Validate manifest size fields |
| docs | `README.md`, `agent_prompt.md` | Update manifest examples |