### PR TITLE
fix: replace non-ASCII characters in cron example script

### DIFF
--- a/examples/cron.daily/secure-backup
+++ b/examples/cron.daily/secure-backup
@@ -15,7 +15,7 @@
 
 set -eu
 
-# ── Configuration ─────────────────────────────────────────────
+# -- Configuration --------------------------------------------
 SOURCES=(
   "/path/to/data1"
   "/path/to/data2"
@@ -26,7 +26,7 @@ ENCRYPTION="age"
 PUBLIC_KEY="age1yourpublickeyhere"
 RETENTION=7
 LOG="/var/log/secure-backup.log"
-# ──────────────────────────────────────────────────────────────
+# --------------------------------------------------------------
 
 SECURE_BACKUP="/usr/bin/secure-backup"
 FAILED=0


### PR DESCRIPTION
Closes #54

Replace Unicode box-drawing characters (U+2500) with plain ASCII dashes in comment separators in `examples/cron.daily/secure-backup`. These caused encoding issues on systems with limited locale support.