### PR TITLE
test: add missing zstd test coverage

### DIFF
--- a/agent_prompt.md
+++ b/agent_prompt.md
@@ -499,6 +499,8 @@
 - ✅ E2E test: full `--compression none` pipeline (backup → verify → restore → diff)
 - ✅ zstd compression support (levels 0-4, `.zst` extension)
 - ✅ E2E test: full `--compression zstd` pipeline (backup → verify → restore → diff)
+- ✅ E2E test: full `--compression zstd --encryption age` pipeline
+- ✅ Retention and list tests include zstd files in mixed-extension scenarios
 - Future: lz4 compression, benchmarking
 
 **Phase 7**: Docker Integration (Optional) — [#16](https://github.com/icemarkom/secure-backup/issues/16)


### PR DESCRIPTION
Add zstd files to mixed-extension tests and zstd+AGE e2e pipeline for complete test coverage.

## Changes

- **`TestApplyPolicy_MixedExtensions`**: Added `.tar.zst.gpg` and `.tar.zst.age` entries (5→7 files, keep 3, delete 4). Ensures retention counts zstd backups alongside gzip/none.
- **`TestListBackups_MixedExtensions`**: Added `.tar.zst.gpg` and `.tar.zst.age` entries (4→6 files). Ensures listing finds zstd backups.
- **`e2e_test.sh`**: Full zstd+AGE pipeline (Steps 40–44): backup → quick verify → full verify → restore → diff. Validates the cross-product of zstd compression with AGE encryption.
- **`agent_prompt.md`**: Updated Phase 4 status.

Ref #15