### PR TITLE
feat: add LZ4 compression support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A high-performance backup tool written in Go that creates encrypted, compressed 
 ## Features
 
 - **Multiple Encryption**: GPG (RSA 4096-bit) and AGE (X25519) encryption
-- **Flexible Compression**: Gzip (default), zstd (fast, high-ratio), or none (passthrough)
+- **Flexible Compression**: Gzip (default), zstd, lz4, or none (passthrough)
 - **Streaming Pipeline**: Efficient memory usage regardless of backup size
 - **Backup Manifests**: Automatic checksum verification and metadata tracking
 - **Retention Management**: Keep only the last N backups
@@ -177,7 +177,7 @@ secure-backup backup \
 ```
 
 This creates two files:
-- `backup_data_20260207_165000.tar.gz.gpg` - Encrypted backup (or `.tar.gz.age` for AGE)
+- `backup_data_20260207_165000.tar.gz.gpg` - Encrypted backup (or `.tar.zst.gpg`, `.tar.lz4.gpg`, `.tar.gz.age`, etc.)
 - `backup_data_20260207_165000_manifest.json` - Manifest with checksum and metadata
 
 ### 4. Preview Operations (Dry-Run)
@@ -322,7 +322,7 @@ Backups include manifest files for integrity verification.
 ### What Are Manifests?
 
 Each backup creates two files:
-- `backup_*.tar.gz.gpg` (or `.tar.gz.age`, `.tar.gpg`, `.tar.age`) - The encrypted backup
+- `backup_*.tar.gz.gpg` / `.tar.zst.gpg` / `.tar.lz4.gpg` / `.tar.gz.age` / `.tar.gpg` / `.tar.age` - The encrypted backup
 - `backup_*_manifest.json` - Manifest with checksum and metadata
 
 **Manifest Contents:**
@@ -442,7 +442,7 @@ If you see warnings about missing manifest files:
 
 - ✅ All core commands implemented and tested
 - ✅ GPG and AGE encryption support
-- ✅ Gzip, zstd, and none (passthrough) compression
+- ✅ Gzip, zstd, lz4, and none (passthrough) compression
 - ✅ 60%+ unit test coverage on core modules
 - ✅ Production hardened (P1-P19 resolved)
 - ✅ Cross-platform builds and `.deb` packaging

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db // indirect
+	github.com/pierrec/lz4/v4 v4.1.25 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -19,6 +19,8 @@ github.com/mattn/go-runewidth v0.0.16 h1:E5ScNMtiwvlvB5paMFdw9p4kSQzbXFikJ5SQO6T
 github.com/mattn/go-runewidth v0.0.16/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db h1:62I3jR2EmQ4l5rM/4FEfDWcRD+abF5XlKShorW5LRoQ=
 github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db/go.mod h1:l0dey0ia/Uv7NcFFVbCLtqEBQbrT4OCwCSKTEv6enCw=
+github.com/pierrec/lz4/v4 v4.1.25 h1:kocOqRffaIbU5djlIBr7Wh+cx82C0vtFb0fOurZHqD0=
+github.com/pierrec/lz4/v4 v4.1.25/go.mod h1:EoQMVJgeeEOMsCqCzqFm2O0cJvljX2nGZjcRIPL34O4=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=

--- a/internal/compress/compress.go
+++ b/internal/compress/compress.go
@@ -31,6 +31,8 @@ const (
 	Gzip Method = iota
 	// Zstd is the zstd compression method.
 	Zstd
+	// Lz4 is the lz4 compression method.
+	Lz4
 	// None disables compression (passthrough).
 	None
 )
@@ -39,6 +41,7 @@ const (
 const (
 	MethodGzip = "gzip"
 	MethodZstd = "zstd"
+	MethodLz4  = "lz4"
 	MethodNone = "none"
 )
 
@@ -49,6 +52,8 @@ func (m Method) String() string {
 		return MethodGzip
 	case Zstd:
 		return MethodZstd
+	case Lz4:
+		return MethodLz4
 	case None:
 		return MethodNone
 	default:
@@ -58,7 +63,7 @@ func (m Method) String() string {
 
 // ValidMethods returns all supported compression methods.
 func ValidMethods() []Method {
-	return []Method{Gzip, Zstd, None}
+	return []Method{Gzip, Zstd, Lz4, None}
 }
 
 // ValidMethodNames returns a comma-separated string of valid method names.
@@ -156,6 +161,8 @@ func NewCompressor(cfg Config) (Compressor, error) {
 		return NewGzipCompressor(cfg.Level)
 	case Zstd:
 		return NewZstdCompressor(cfg.Level)
+	case Lz4:
+		return NewLz4Compressor(cfg.Level)
 	case None:
 		return NewNoneCompressor(), nil
 	default:

--- a/internal/compress/compress_test.go
+++ b/internal/compress/compress_test.go
@@ -31,6 +31,7 @@ func TestMethod_String(t *testing.T) {
 	}{
 		{"Gzip", Gzip, "gzip"},
 		{"Zstd", Zstd, "zstd"},
+		{"Lz4", Lz4, "lz4"},
 		{"None", None, "none"},
 		{"unknown", Method(99), "unknown(99)"},
 	}
@@ -51,12 +52,15 @@ func TestParseMethod(t *testing.T) {
 	}{
 		{"gzip lowercase", "gzip", Gzip, false},
 		{"zstd lowercase", "zstd", Zstd, false},
+		{"lz4 lowercase", "lz4", Lz4, false},
 		{"none lowercase", "none", None, false},
 		{"GZIP uppercase", "GZIP", Gzip, false},
 		{"ZSTD uppercase", "ZSTD", Zstd, false},
+		{"LZ4 uppercase", "LZ4", Lz4, false},
 		{"NONE uppercase", "NONE", None, false},
 		{"Gzip mixed case", "Gzip", Gzip, false},
 		{"Zstd mixed case", "Zstd", Zstd, false},
+		{"Lz4 mixed case", "Lz4", Lz4, false},
 		{"None mixed case", "None", None, false},
 		{"unknown method", "bzip2", Method(0), true},
 		{"empty string", "", Method(0), true},
@@ -78,9 +82,10 @@ func TestParseMethod(t *testing.T) {
 
 func TestValidMethods(t *testing.T) {
 	methods := ValidMethods()
-	assert.Len(t, methods, 3)
+	assert.Len(t, methods, 4)
 	assert.Contains(t, methods, Gzip)
 	assert.Contains(t, methods, Zstd)
+	assert.Contains(t, methods, Lz4)
 	assert.Contains(t, methods, None)
 }
 
@@ -88,8 +93,9 @@ func TestValidMethodNames(t *testing.T) {
 	names := ValidMethodNames()
 	assert.Contains(t, names, MethodGzip)
 	assert.Contains(t, names, MethodZstd)
+	assert.Contains(t, names, MethodLz4)
 	assert.Contains(t, names, MethodNone)
-	assert.Equal(t, "gzip, zstd, none", names)
+	assert.Equal(t, "gzip, zstd, lz4, none", names)
 }
 
 func TestGzipCompressor_Type(t *testing.T) {
@@ -115,10 +121,13 @@ func TestResolveMethod(t *testing.T) {
 		{"gzip age", "backup_test_20260101_120000.tar.gz.age", Gzip, false},
 		{"zstd gpg", "backup_test_20260101_120000.tar.zst.gpg", Zstd, false},
 		{"zstd age", "backup_test_20260101_120000.tar.zst.age", Zstd, false},
+		{"lz4 gpg", "backup_test_20260101_120000.tar.lz4.gpg", Lz4, false},
+		{"lz4 age", "backup_test_20260101_120000.tar.lz4.age", Lz4, false},
 		{"none gpg", "backup_test_20260101_120000.tar.gpg", None, false},
 		{"none age", "backup_test_20260101_120000.tar.age", None, false},
 		{"full path gzip", "/backups/daily/backup_data.tar.gz.gpg", Gzip, false},
 		{"full path zstd", "/backups/daily/backup_data.tar.zst.gpg", Zstd, false},
+		{"full path lz4", "/backups/daily/backup_data.tar.lz4.gpg", Lz4, false},
 		{"full path none", "/backups/daily/backup_data.tar.gpg", None, false},
 		{"unknown extension", "backup.zip", Method(0), true},
 		{"no extension", "backup", Method(0), true},

--- a/internal/compress/lz4.go
+++ b/internal/compress/lz4.go
@@ -1,0 +1,101 @@
+// Copyright 2026 Marko Milivojevic
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package compress
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/icemarkom/secure-backup/internal/common"
+	"github.com/pierrec/lz4/v4"
+)
+
+// Lz4Compressor implements the Compressor interface using lz4.
+type Lz4Compressor struct {
+	level lz4.CompressionLevel
+}
+
+// NewLz4Compressor creates a new lz4 compressor with the specified level.
+// If level is 0, uses lz4.Fast (default).
+// Valid levels: 0 (fast/default), 1-9 (increasing compression).
+func NewLz4Compressor(level int) (*Lz4Compressor, error) {
+	if level < 0 || level > 9 {
+		return nil, fmt.Errorf("invalid lz4 compression level: %d (must be 0-9)", level)
+	}
+
+	var compLevel lz4.CompressionLevel
+	switch {
+	case level == 0:
+		compLevel = lz4.Fast
+	default:
+		compLevel = lz4.CompressionLevel(1 << (8 + level))
+	}
+
+	return &Lz4Compressor{level: compLevel}, nil
+}
+
+// Compress compresses the input stream using lz4.
+func (c *Lz4Compressor) Compress(input io.Reader) (io.Reader, error) {
+	pr, pw := io.Pipe()
+
+	go func() {
+		defer pw.Close()
+
+		enc := lz4.NewWriter(pw)
+		enc.Apply(lz4.CompressionLevelOption(c.level))
+
+		if _, err := io.CopyBuffer(enc, input, common.NewBuffer()); err != nil {
+			pw.CloseWithError(fmt.Errorf("compression failed: %w", err))
+			return
+		}
+
+		if err := enc.Close(); err != nil {
+			pw.CloseWithError(fmt.Errorf("failed to close lz4 writer: %w", err))
+			return
+		}
+	}()
+
+	return pr, nil
+}
+
+// Decompress decompresses the input stream using lz4.
+func (c *Lz4Compressor) Decompress(input io.Reader) (io.Reader, error) {
+	pr, pw := io.Pipe()
+
+	go func() {
+		defer pw.Close()
+
+		dec := lz4.NewReader(input)
+
+		if _, err := io.CopyBuffer(pw, dec, common.NewBuffer()); err != nil {
+			pw.CloseWithError(fmt.Errorf("decompression failed: %w", err))
+			return
+		}
+	}()
+
+	return pr, nil
+}
+
+// Type returns the compression method type.
+func (c *Lz4Compressor) Type() Method {
+	return Lz4
+}
+
+// Extension returns the file extension for lz4 compressed files.
+func (c *Lz4Compressor) Extension() string {
+	return ".lz4"
+}

--- a/internal/compress/lz4_test.go
+++ b/internal/compress/lz4_test.go
@@ -1,0 +1,159 @@
+// Copyright 2026 Marko Milivojevic
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package compress
+
+import (
+	"bytes"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLz4Compressor_CompressDecompress(t *testing.T) {
+	tests := []struct {
+		name  string
+		data  string
+		level int
+	}{
+		{
+			name:  "simple text",
+			data:  "Hello, World!",
+			level: 0, // default
+		},
+		{
+			name:  "empty string",
+			data:  "",
+			level: 0,
+		},
+		{
+			name:  "large text",
+			data:  strings.Repeat("The quick brown fox jumps over the lazy dog. ", 1000),
+			level: 3,
+		},
+		{
+			name:  "binary-like data",
+			data:  string([]byte{0, 1, 2, 3, 255, 254, 253}),
+			level: 5,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create compressor
+			compressor, err := NewLz4Compressor(tt.level)
+			require.NoError(t, err)
+			assert.Equal(t, ".lz4", compressor.Extension())
+
+			// Compress
+			input := bytes.NewReader([]byte(tt.data))
+			compressed, err := compressor.Compress(input)
+			require.NoError(t, err)
+
+			// Read compressed data
+			compressedData, err := io.ReadAll(compressed)
+			require.NoError(t, err)
+
+			// Decompress
+			decompressed, err := compressor.Decompress(bytes.NewReader(compressedData))
+			require.NoError(t, err)
+
+			// Read decompressed data
+			decompressedData, err := io.ReadAll(decompressed)
+			require.NoError(t, err)
+
+			// Verify round-trip
+			assert.Equal(t, tt.data, string(decompressedData))
+		})
+	}
+}
+
+func TestLz4Compressor_InvalidLevel(t *testing.T) {
+	tests := []struct {
+		name  string
+		level int
+	}{
+		{"negative", -1},
+		{"too high", 10},
+		{"way too high", 100},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := NewLz4Compressor(tt.level)
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), "invalid lz4 compression level")
+		})
+	}
+}
+
+func TestLz4Compressor_ValidLevels(t *testing.T) {
+	validLevels := []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}
+
+	for _, level := range validLevels {
+		compressor, err := NewLz4Compressor(level)
+		require.NoError(t, err)
+		assert.NotNil(t, compressor)
+	}
+}
+
+func TestLz4Compressor_CompressionRatio(t *testing.T) {
+	// Test that compression actually reduces size for repetitive data
+	data := strings.Repeat("AAAA", 10000) // Highly compressible
+
+	compressor, err := NewLz4Compressor(0)
+	require.NoError(t, err)
+
+	compressed, err := compressor.Compress(strings.NewReader(data))
+	require.NoError(t, err)
+
+	compressedData, err := io.ReadAll(compressed)
+	require.NoError(t, err)
+
+	// Should compress to much less than original size
+	assert.Less(t, len(compressedData), len(data)/10, "compression ratio should be significant for repetitive data")
+}
+
+func TestLz4Compressor_InvalidData(t *testing.T) {
+	compressor, err := NewLz4Compressor(0)
+	require.NoError(t, err)
+
+	// Try to decompress invalid lz4 data — NewReader succeeds, error comes on read
+	reader, err := compressor.Decompress(bytes.NewReader([]byte("this is not lz4 data")))
+	if err != nil {
+		// Some implementations error on NewReader
+		return
+	}
+	_, err = io.ReadAll(reader)
+	assert.Error(t, err)
+}
+
+func TestLz4Compressor_Type(t *testing.T) {
+	compressor, err := NewLz4Compressor(0)
+	require.NoError(t, err)
+	assert.Equal(t, Lz4, compressor.Type())
+}
+
+func TestNewCompressor_Lz4(t *testing.T) {
+	compressor, err := NewCompressor(Config{Method: Lz4, Level: 0})
+	require.NoError(t, err)
+	require.NotNil(t, compressor)
+	assert.Equal(t, Lz4, compressor.Type())
+	assert.Equal(t, ".lz4", compressor.Extension())
+}

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -49,6 +49,16 @@ func TestManifestPath(t *testing.T) {
 			want:       "backup_data_20260215_120000_manifest.json",
 		},
 		{
+			name:       "gpg encrypted lz4",
+			backupPath: "backup_data_20260215_120000.tar.lz4.gpg",
+			want:       "backup_data_20260215_120000_manifest.json",
+		},
+		{
+			name:       "age encrypted lz4",
+			backupPath: "backup_data_20260215_120000.tar.lz4.age",
+			want:       "backup_data_20260215_120000_manifest.json",
+		},
+		{
 			name:       "age encrypted gzip",
 			backupPath: "backup_data_20260215_120000.tar.gz.age",
 			want:       "backup_data_20260215_120000_manifest.json",


### PR DESCRIPTION
## Summary

Add LZ4 compression support using `pierrec/lz4/v4 v4.1.25`.

### Changes

**New files:**
- `internal/compress/lz4.go` — `Lz4Compressor` implementation (levels 0-9, `.lz4` extension)
- `internal/compress/lz4_test.go` — 7 unit tests (parity with gzip/zstd)

**Updated files:**
- `compress.go` — `Lz4` iota, `MethodLz4` constant, wired into `String()`, `ValidMethods()`, `NewCompressor()`
- `compress_test.go` — LZ4 entries in all 5 shared test tables
- `manifest_test.go` — LZ4 GPG/AGE entries in `TestManifestPath`
- `policy_test.go` — LZ4 in `IsBackupFile`, `MixedExtensions`, `ListBackups`
- `e2e_test.sh` — LZ4+GPG and LZ4+AGE full pipelines (steps 50-64)
- `README.md`, `USAGE.md`, `agent_prompt.md` — documentation updates

### Design

No CLI wiring changes needed — `ParseMethod()`, `ResolveMethod()`, retention, and manifest all work dynamically via `init()`.

Level mapping: 0=Fast (default), 1-9=increasing compression via `lz4.CompressionLevel(1 << (8 + level))`.

### Testing

- ✅ Unit tests: 7 LZ4-specific + shared compress tests
- ✅ Manifest tests: `TestManifestPath` for `.tar.lz4.gpg`/`.tar.lz4.age`
- ✅ Retention tests: `IsBackupFile`, `MixedExtensions`, `ListBackups`
- ✅ E2E tests: LZ4+GPG and LZ4+AGE full backup→verify→restore→diff
- ✅ All 10 packages pass, `go vet` clean

Closes #15