### PR TITLE
feat: manifest-first backup management

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ A high-performance backup tool written in Go that creates encrypted, compressed 
 - **Flexible Compression**: Gzip (default), zstd, lz4, or none (passthrough)
 - **Streaming Pipeline**: Efficient memory usage regardless of backup size
 - **Backup Manifests**: Automatic checksum verification and metadata tracking
-- **Retention Management**: Keep only the last N backups
+- **Retention Management**: Per-source retention — keeps last N backups grouped by hostname and source path
 - **Verify Integrity**: Quick and full verification modes
-- **List Backups**: View all backups with age and size information
+- **List Backups**: Partitioned view — managed (with manifest) vs orphan backups
 - **Production Hardened**: Atomic writes, backup locking, signal handling, secure defaults
 - **Cross-platform**: Linux, macOS, Windows (amd64/arm64)
 - **Release Packaging**: `.deb` packages, GitHub Releases, apt repository

--- a/agent_prompt.md
+++ b/agent_prompt.md
@@ -219,6 +219,7 @@ Key architectural decisions that affect future development:
 | 2026-02-18 | Docker integration abandoned | General-purpose directory backup tool; Docker volumes backed up via mount paths. Closed [#16](https://github.com/icemarkom/secure-backup/issues/16) |
 | 2026-02-18 | agent_prompt.md streamlined | Removed phases/productionization terminology, use GH issues for tracking. Rules of engagement elevated to top. Reduced 1008→232 lines |
 | 2026-02-18 | Sidecar-only manifests (no embedding) | Evaluated 4 embedding strategies (tar entry, trailing footer, outer wrapper, hybrid). All add complexity/fragility or break format compatibility with standard GPG/AGE tools. Sidecar is simple, reliable, and preserves `gpg --decrypt` fallback. Closed [#44](https://github.com/icemarkom/secure-backup/issues/44) |
+| 2026-02-18 | Manifest-first backup management | Retention scoped by `(hostname, source_path)` from manifest. List partitions into managed/orphan sections. Orphans excluded from retention with stderr warning. Resolves [#45](https://github.com/icemarkom/secure-backup/issues/45) and [#43](https://github.com/icemarkom/secure-backup/issues/43) |
 
 ---
 
@@ -227,7 +228,7 @@ Key architectural decisions that affect future development:
 Track all planned work via [GitHub Issues](https://github.com/icemarkom/secure-backup/issues).
 
 Key open items:
-- [#45](https://github.com/icemarkom/secure-backup/issues/45) — Manifest-first backup management
+- [#65](https://github.com/icemarkom/secure-backup/issues/65) — Adopt subcommand for orphan backups
 
 ---
 

--- a/docs/secure-backup.1
+++ b/docs/secure-backup.1
@@ -85,8 +85,10 @@ or
 .BR none .
 .TP
 .BR \-\-retention " " \fIN\fR
-Number of backups to keep in the destination directory.
-Older backups (and their manifests) are deleted after a successful backup.
+Number of managed backups to keep per source in the destination directory.
+Retention is scoped by hostname and source path from manifest files;
+backups from different sources or hosts are retained independently.
+Orphan backups (no manifest) are excluded with a warning to stderr.
 Default: 0 (keep all).
 .TP
 .B \-\-skip-manifest
@@ -201,6 +203,11 @@ Implies
 .\" ---
 .SS list
 List available backups in a directory.
+Output is partitioned into
+.B Managed Backups
+(with manifest metadata) and
+.B Orphan Backups
+(no manifest, limited info).
 This is a query command and always produces output.
 .TP
 .BR \-\-dest " " \fIdir\fR " (required)"


### PR DESCRIPTION
## Summary

Implements manifest-first backup management (#45) and resolves retention scoping (#43).

### Changes

**Retention scoping** (`internal/retention/policy.go`):
- `ApplyPolicy` groups managed backups by `(hostname, source_path)` from manifest metadata
- Retention applied independently per group — backing up `/data` and `/logs` to the same destination keeps N of each
- Orphan backups (no manifest) excluded from retention with stderr warning

**List partitioning** (`cmd/list.go`):
- Output split into **Managed Backups** (Source, Host, Checksum, Tool) and **Orphan Backups** (limited info)

**Testing**:
- 6 new unit tests for scoped retention (two-source, different-hosts, all-orphans, mixed, orphan-not-counted, corrupt-manifest)
- 12 existing tests updated with `writeTestManifest` helper
- 3 new E2E tests (list partitioning, orphan retention exclusion, scoped retention)

**Documentation**: USAGE.md, README.md, man page, agent_prompt.md

Resolves #45
Resolves #43