### PR TITLE
fix: improve release notes extraction reliability in CI

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,12 +25,13 @@ jobs:
 
       - name: Extract tag annotation
         run: |
-          git for-each-ref --format='%(contents)' "refs/tags/${GITHUB_REF_NAME}" > /tmp/release-notes.md
+          git tag -l --format='%(contents)' "${GITHUB_REF_NAME}" > /tmp/release-notes.md
           if [ ! -s /tmp/release-notes.md ]; then
             echo "::error::Tag ${GITHUB_REF_NAME} has no annotation. Use 'git tag -a' to create annotated tags."
             exit 1
           fi
-          echo "Release notes extracted ($(wc -l < /tmp/release-notes.md) lines)"
+          echo "Release notes extracted ($(wc -l < /tmp/release-notes.md) lines):"
+          cat /tmp/release-notes.md
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6


### PR DESCRIPTION
Replace `git for-each-ref --format='%(contents)'` with `git tag -l --format='%(contents)'` for extracting annotated tag messages.

The `for-each-ref` approach has been observed to truncate multi-line tag annotations in GitHub Actions runners (happened in both v1.4.0 and v1.4.1 releases). Also adds `cat` output of extracted notes to the CI log for easier diagnosis of any future issues.